### PR TITLE
2021c Yuki

### DIFF
--- a/Chapter01/yuki1184053.py
+++ b/Chapter01/yuki1184053.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Mar 18 20:54:03 2021
+
+@author: Tuf Gaming
+"""
+
+from sklearn import tree
+import pandas as pd
+
+def prepoc(datapath):
+    pencak = pd.read_csv(datapath, sep=',')
+    len(pencak)
+    
+    # shuffle data
+    pencak = pencak.sample(frac=1)
+    pencak_train = pencak[:1000]
+    pencak_test = pencak[500:]
+
+    pencak_train_att = pencak_train.drop(['Bankrupt'], axis=1)
+    pencak_train_pass = pencak_train['Bankrupt']
+    
+    pencak_test_att = pencak_test.drop(['Bankrupt'], axis=1)
+    pencak_test_pass = pencak_test['Bankrupt']
+    
+    pencak_att = pencak.drop(['Bankrupt'], axis=1)
+    pencak_pass = pencak['Bankrupt']
+    return pencak_train_att,pencak_train_pass,pencak_test_att,pencak_test_pass,pencak_att,pencak_pass
+
+def training(pencak_train_att,pencak_train_pass):
+    silat = tree.DecisionTreeClassifier(criterion="entropy", max_depth=5)
+    silat = silat.fit(pencak_train_att, pencak_train_pass)
+    return silat
+
+def testing(silat,testdataframe):
+    return silat.predict(testdataframe)

--- a/test_app.py
+++ b/test_app.py
@@ -84,3 +84,14 @@ class TestApp(unittest.TestCase):
         ambilsatuhasiltesting = hasiltestingsemua[1]
         self.assertLessEqual(ambilsatuhasiltesting, 8)
         
+    def test_02_yuki_1184053(self):
+        from Chapter01.yuki1184053 import prepoc,training,testing
+        dataset='Chapter01/dataset/bankruptcy_prediction.csv'
+        pencak_train_att,pencak_train_pass,pencak_test_att,pencak_test_pass,pencak_att,pencak_pass= prepoc(dataset)
+        silat = training(pencak_train_att,pencak_train_pass)
+        hasiltestingsemua =     testing(silat,pencak_test_att)
+        print('\n hasil testing : ')
+        print(hasiltestingsemua)
+        ambilsatuhasiltesting = hasiltestingsemua[0]
+        self.assertLessEqual(ambilsatuhasiltesting, 1)
+


### PR DESCRIPTION
data Bankruptcy data dari the Taiwan Economic Journal for the tahun 1999–2009
1. dataset yang digunakan tentang prediksi kebaangkrutan di dalam perusahaan
2. atribut yang tersedia di dalam dataset Bankrupt, Research and development expense rate, Dll
3. label yang digunakan adalah ['Bankrupt'] untuk memprediksi apakah perusahan tersebut bangkrut atau tidak 
4. dengan output 0 dan 1 dimana 0 perusahan tersebut bangkrut 1 tidak bangkrut
